### PR TITLE
Add optional custom flags to overwrite default flags

### DIFF
--- a/src/Converter/GhostscriptConverterCommand.php
+++ b/src/Converter/GhostscriptConverterCommand.php
@@ -8,6 +8,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace Xthiago\PDFVersionConverter\Converter;
 
 use Symfony\Component\Process\Process;
@@ -22,10 +23,14 @@ class GhostscriptConverterCommand
     /**
      * @var Filesystem
      */
-    protected $baseCommand = 'gs -sDEVICE=pdfwrite -dCompatibilityLevel=%s -dPDFSETTINGS=/screen -dNOPAUSE -dQUIET -dBATCH -dColorConversionStrategy=/LeaveColorUnchanged -dEncodeColorImages=false -dEncodeGrayImages=false -dEncodeMonoImages=false -dDownsampleMonoImages=false -dDownsampleGrayImages=false -dDownsampleColorImages=false -dAutoFilterColorImages=false -dAutoFilterGrayImages=false -dColorImageFilter=/FlateEncode -dGrayImageFilter=/FlateEncode  -sOutputFile=%s %s';
+    protected $baseCommand = 'gs -sDEVICE=pdfwrite -dCompatibilityLevel=%s -dPDFSETTINGS=/screen -dQUIET ';
 
-    public function __construct()
+    protected $defaultFlags = '-dColorConversionStrategy=/LeaveColorUnchanged -dEncodeColorImages=false -dEncodeGrayImages=false -dEncodeMonoImages=false -dDownsampleMonoImages=false -dDownsampleGrayImages=false -dDownsampleColorImages=false -dAutoFilterColorImages=false -dAutoFilterGrayImages=false -dColorImageFilter=/FlateEncode -dGrayImageFilter=/FlateEncode';
+
+    public function __construct($customFlags = null)
     {
+        $this->baseCommand .= $customFlags ?? $this->defaultFlags;
+        $this->baseCommand .= ' -o %s %s';
     }
 
     public function run($originalFile, $newFile, $newVersion)


### PR DESCRIPTION
* Using `-o` flag shorthand.

From ghostscript docs: 
```
For instance, to convert somefile.ps to JPEG image files, one per page, use:

gs -sDEVICE=jpeg -o out-%d.jpg somefile.ps
is equivalent to:

gs -sDEVICE=jpeg -sOutputFile=out-%d.jpg -dBATCH -dNOPAUSE somefile.ps
```

* Added option to provide custom flags to the command which overwrite the default flags. 