### PR TITLE
NEW Allow installation against PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     },
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5 || ^8.0",
         "symfony/filesystem": "^5.0",
         "symfony/process": "^5.0"
     },


### PR DESCRIPTION
Haven't hit any issues with code compatibility, so this should be all that's required for PHP 8 support.